### PR TITLE
Feat: 게시물 이미지 수정, 삭제 기능 및 파라미터 변경

### DIFF
--- a/src/main/java/com/cine/back/batch/controller/BoxOfficeController.java
+++ b/src/main/java/com/cine/back/batch/controller/BoxOfficeController.java
@@ -2,7 +2,9 @@ package com.cine.back.batch.controller;
 
 import com.cine.back.batch.response.BoxOfficeResponse;
 import com.cine.back.batch.service.ApiCall;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,7 +22,7 @@ public class BoxOfficeController {
     }
 
     @GetMapping("/getMovieInfo")
-    public ResponseEntity<BoxOfficeResponse> getBoxOfficeInfo(){
+    public ResponseEntity<BoxOfficeResponse> getBoxOfficeInfo() {
         return ResponseEntity.ok(apiCall.getDailyBoxOffice());
     }
 }

--- a/src/main/java/com/cine/back/board/comment/controller/CommentController.java
+++ b/src/main/java/com/cine/back/board/comment/controller/CommentController.java
@@ -29,6 +29,7 @@ public class CommentController implements CommentControllerDocs {
     @PostMapping("/post/{postNo}/comment")
     public ResponseEntity<CommentResponseDto> saveComment(Long postNo, CommentRequestDto requestDto) {
         log.info("댓글 저장 컨트롤러, 게시글 NO: {}", postNo);
+        log.info("댓글 저장 내용: {}", requestDto.content());
         CommentResponseDto responseDto = commentService.writeComment(postNo, requestDto);
         return ResponseEntity.ok().body(responseDto);
     }

--- a/src/main/java/com/cine/back/board/comment/controller/CommentController.java
+++ b/src/main/java/com/cine/back/board/comment/controller/CommentController.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -50,7 +50,7 @@ public class CommentController implements CommentControllerDocs {
     }
 
     @Override
-    @PutMapping("/post/{postNo}/comment/{commentNo}")
+    @PatchMapping("/post/{postNo}/comment/{commentNo}")
     public ResponseEntity<Long> updateComment(Long postNo, Long commentNo,
             CommentRequestDto commentRequestDto) {
         log.info("특정 댓글 수정 컨트롤러, Comment No: {}", commentNo);

--- a/src/main/java/com/cine/back/board/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/com/cine/back/board/comment/controller/CommentControllerDocs.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 
 import com.cine.back.board.comment.dto.CommentRequestDto;
@@ -24,7 +25,7 @@ public interface CommentControllerDocs {
                         @ApiResponse(responseCode = "400", description = "댓글 저장 실패"),
                         @ApiResponse(responseCode = "500", description = "서버 내부 오류") })
         public ResponseEntity<CommentResponseDto> saveComment(@PathVariable(value = "postNo") Long postNo,
-                        @RequestPart(value = "dto") CommentRequestDto requestDto);
+                        @RequestBody CommentRequestDto requestDto);
 
         // 게시글 댓글 조회
         @Operation(summary = "댓글 조회", description = "게시판 No로 해당 댓글을 조회합니다.")
@@ -49,6 +50,6 @@ public interface CommentControllerDocs {
                         @ApiResponse(responseCode = "500", description = "서버 내부 오류") })
         public ResponseEntity<Long> updateComment(@PathVariable(value = "postNo") Long postNo,
                         @PathVariable(value = "commentNo") Long commentNo,
-                        @RequestPart(value = "dto") CommentRequestDto commentRequestDto);
+                        @RequestBody CommentRequestDto commentRequestDto);
 
 }

--- a/src/main/java/com/cine/back/board/comment/controller/ReplyController.java
+++ b/src/main/java/com/cine/back/board/comment/controller/ReplyController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,8 +51,8 @@ public class ReplyController implements ReplyControllerDocs {
     }
 
     @Override
-    @PutMapping("/comment/{commentNo}/reply/{replyNo}")
-    public ResponseEntity<Long> updateComment(Long commentNo, Long replyNo, CommentRequestDto commentRequestDto) {
+    @PatchMapping("/comment/{commentNo}/reply/{replyNo}")
+    public ResponseEntity<Long> updateReply(Long commentNo, Long replyNo, CommentRequestDto commentRequestDto) {
         log.info("특정 대댓글 수정 컨트롤러, Reply No: {}", replyNo);
         ReplyResponseDto replyResponseDto = replyService.modifyReply(replyNo, commentRequestDto);
         return ResponseEntity.ok().body(replyResponseDto.commentNo());

--- a/src/main/java/com/cine/back/board/comment/controller/ReplyControllerDocs.java
+++ b/src/main/java/com/cine/back/board/comment/controller/ReplyControllerDocs.java
@@ -49,7 +49,7 @@ public interface ReplyControllerDocs {
                         @ApiResponse(responseCode = "200", description = "댓글 수정 성공"),
                         @ApiResponse(responseCode = "400", description = "댓글 수정 실패"),
                         @ApiResponse(responseCode = "500", description = "서버 내부 오류") })
-        public ResponseEntity<Long> updateComment(@PathVariable(value = "commentNo") Long commentNo,
+        public ResponseEntity<Long> updateReply(@PathVariable(value = "commentNo") Long commentNo,
                         @PathVariable(value = "replyNo") Long replyNo,
                         @RequestBody CommentRequestDto commentRequestDto);
 

--- a/src/main/java/com/cine/back/board/comment/controller/ReplyControllerDocs.java
+++ b/src/main/java/com/cine/back/board/comment/controller/ReplyControllerDocs.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestPart;
 
 import com.cine.back.board.comment.dto.CommentRequestDto;
@@ -24,7 +25,7 @@ public interface ReplyControllerDocs {
                         @ApiResponse(responseCode = "400", description = "댓글 저장 실패"),
                         @ApiResponse(responseCode = "500", description = "서버 내부 오류") })
         public ResponseEntity<ReplyResponseDto> saveReply(@PathVariable(value = "commentNo") Long commentNo,
-                        @RequestPart(value = "dto") CommentRequestDto requestDto);
+                        @RequestBody CommentRequestDto requestDto);
 
         // 게시글 댓글 조회
         @Operation(summary = "대댓글 조회", description = "댓글 No로 해당 대댓글을 조회합니다.")
@@ -50,6 +51,6 @@ public interface ReplyControllerDocs {
                         @ApiResponse(responseCode = "500", description = "서버 내부 오류") })
         public ResponseEntity<Long> updateComment(@PathVariable(value = "commentNo") Long commentNo,
                         @PathVariable(value = "replyNo") Long replyNo,
-                        @RequestPart(value = "dto") CommentRequestDto commentRequestDto);
+                        @RequestBody CommentRequestDto commentRequestDto);
 
 }

--- a/src/main/java/com/cine/back/board/comment/controller/ReplyResponseDto.java
+++ b/src/main/java/com/cine/back/board/comment/controller/ReplyResponseDto.java
@@ -1,5 +1,0 @@
-package com.cine.back.board.comment.controller;
-
-public class ReplyResponseDto {
-
-}

--- a/src/main/java/com/cine/back/board/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/cine/back/board/comment/dto/CommentResponseDto.java
@@ -7,9 +7,11 @@ public record CommentResponseDto(
         Long commentNo,
         String userId,
         String content,
-        LocalDateTime date) {
+        LocalDateTime createDate,
+        LocalDateTime updateDate) {
+
     public static CommentResponseDto of(Long postNo, Long commentNo, String userId, String content,
-            LocalDateTime date) {
-        return new CommentResponseDto(postNo, commentNo, userId, content, date);
+            LocalDateTime createDate, LocalDateTime updateDate) {
+        return new CommentResponseDto(postNo, commentNo, userId, content, createDate, updateDate);
     }
 }

--- a/src/main/java/com/cine/back/board/comment/dto/ReplyResponseDto.java
+++ b/src/main/java/com/cine/back/board/comment/dto/ReplyResponseDto.java
@@ -7,9 +7,12 @@ public record ReplyResponseDto(
         Long replyNo,
         String userId,
         String content,
-        LocalDateTime date) {
-    public static ReplyResponseDto of(Long commentNo, Long replyNo, String userId, String content, LocalDateTime date) {
-        return new ReplyResponseDto(commentNo, replyNo, userId, content, date);
+        LocalDateTime createDate,
+        LocalDateTime updateDate) {
+    public static ReplyResponseDto of(Long commentNo, Long replyNo, String userId, String content,
+            LocalDateTime createDate,
+            LocalDateTime updateDate) {
+        return new ReplyResponseDto(commentNo, replyNo, userId, content, createDate, updateDate);
     }
 
 }

--- a/src/main/java/com/cine/back/board/comment/service/CommentMapper.java
+++ b/src/main/java/com/cine/back/board/comment/service/CommentMapper.java
@@ -41,7 +41,8 @@ public class CommentMapper {
                 commentEntity.getCommentNo(),
                 commentEntity.getUserId(),
                 commentEntity.getCommentContent(),
-                commentEntity.getCreatedDate());
+                commentEntity.getCreatedDate(),
+                commentEntity.getUpdateDate());
     }
 
     public List<CommentResponseDto> toResponseDtos(List<CommentEntity> commentEntities) {
@@ -62,7 +63,8 @@ public class CommentMapper {
                 replyEntity.getReplyNo(),
                 replyEntity.getUserId(),
                 replyEntity.getReplyContent(),
-                replyEntity.getCreatedDate());
+                replyEntity.getCreatedDate(),
+                replyEntity.getUpdateDate());
     }
 
     public List<ReplyResponseDto> toReplyResponseDtos(List<ReplyEntity> replyEntities) {

--- a/src/main/java/com/cine/back/board/comment/service/CommentService.java
+++ b/src/main/java/com/cine/back/board/comment/service/CommentService.java
@@ -10,10 +10,8 @@ import com.cine.back.board.comment.dto.CommentResponseDto;
 import com.cine.back.board.comment.entity.CommentEntity;
 import com.cine.back.board.comment.repository.CommentRepository;
 import com.cine.back.board.post.entity.PostEntity;
-import com.cine.back.board.post.repository.PostRepository;
 import com.cine.back.board.util.EntityUtil;
 
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/cine/back/board/post/controller/PostController.java
+++ b/src/main/java/com/cine/back/board/post/controller/PostController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,27 +46,28 @@ public class PostController implements PostControllerDocs {
     }
 
     @Override
-    @GetMapping("/post/{no}")
-    public ResponseEntity<PostResponseDto> getBoardById(Long boardNo) {
-        log.info("특정 게시글 반환 컨트롤러, Board No: {}", boardNo);
-        PostResponseDto board = boardService.getByBoardNo(boardNo);
+    @GetMapping("/post/{postNo}")
+    public ResponseEntity<PostResponseDto> getBoardById(Long postNo) {
+        log.info("특정 게시글 반환 컨트롤러, Post No: {}", postNo);
+        PostResponseDto board = boardService.getByBoardNo(postNo);
         return ResponseEntity.ok().body(board);
     }
 
     @Override
-    @DeleteMapping("/post/delete/{no}")
-    public ResponseEntity<String> deleteBoard(Long boardNo) throws IOException {
-        log.info("특정 게시글 삭제 컨트롤러, Board No: {}", boardNo);
-        boardService.deleteBoard(boardNo);
+    @DeleteMapping("/post/delete/{postNo}")
+    public ResponseEntity<String> deleteBoard(Long postNo) throws IOException {
+        log.info("특정 게시글 삭제 컨트롤러, Post No: {}", postNo);
+        boardService.deleteBoard(postNo);
         return ResponseEntity.ok().body("게시글 삭제 성공");
     }
 
     @Override
-    @PutMapping("/post/modify/{no}")
-    public ResponseEntity<Long> updateBoard(Long boardNo, PostRequestDto boardDto, MultipartFile imgFile)
+    @PatchMapping("/post/modify/{postNo}")
+    public ResponseEntity<Long> updateBoard(Long postNo, PostRequestDto boardDto, MultipartFile imgFile,
+            boolean deleteImage)
             throws IOException {
-        log.info("특정 게시글 수정 컨트롤러, Board No: {}", boardNo);
-        PostResponseDto responseDto = boardService.modifyBoard(boardNo, boardDto, imgFile);
+        log.info("특정 게시글 수정 컨트롤러, Board No: {}", postNo);
+        PostResponseDto responseDto = boardService.modifyBoard(postNo, boardDto, imgFile, deleteImage);
         return ResponseEntity.ok().body(responseDto.postNo());
     }
 

--- a/src/main/java/com/cine/back/board/post/controller/PostControllerDocs.java
+++ b/src/main/java/com/cine/back/board/post/controller/PostControllerDocs.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -40,14 +41,14 @@ public interface PostControllerDocs {
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "글 세부 조회 성공"),
                         @ApiResponse(responseCode = "400", description = "글 세부 조회 실패") })
-        ResponseEntity<PostResponseDto> getBoardById(@PathVariable(value = "no") Long boardNo);
+        ResponseEntity<PostResponseDto> getBoardById(@PathVariable(value = "postNo") Long postNo);
 
         // 글 삭제
         @Operation(summary = "게시판 글 삭제", description = "게시판에서 글을 삭제합니다.")
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "글 삭제 성공"),
                         @ApiResponse(responseCode = "400", description = "글 삭제 실패") })
-        ResponseEntity<String> deleteBoard(@PathVariable(value = "no") Long boardNo) throws IOException;
+        ResponseEntity<String> deleteBoard(@PathVariable(value = "postNo") Long postNo) throws IOException;
 
         // 글 수정
         @Operation(summary = "게시판 글 수정", description = "게시판에 저장된 글을 수정합니다.")
@@ -55,7 +56,9 @@ public interface PostControllerDocs {
                         @ApiResponse(responseCode = "200", description = "글 수정 성공"),
                         @ApiResponse(responseCode = "400", description = "글 수정 실패"),
                         @ApiResponse(responseCode = "500", description = "서버 내부 오류") })
-        ResponseEntity<Long> updateBoard(@PathVariable(value = "no") Long boardNo,
+        ResponseEntity<Long> updateBoard(@PathVariable(value = "postNo") Long postNo,
                         @RequestPart(value = "dto") PostRequestDto boardDto,
-                        @RequestPart(value = "file") MultipartFile imgFile) throws IOException;
+                        @RequestPart(value = "file") MultipartFile imgFile,
+                        @RequestParam(value = "deleteImage", required = false, defaultValue = "false") boolean deleteImage)
+                        throws IOException;
 }

--- a/src/main/java/com/cine/back/board/post/service/FileService.java
+++ b/src/main/java/com/cine/back/board/post/service/FileService.java
@@ -8,7 +8,9 @@ import org.springframework.web.multipart.MultipartFile;
 import com.cine.back.config.file.S3Uploader;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FileService {
@@ -16,10 +18,12 @@ public class FileService {
     private final S3Uploader s3Uploader;
 
     public String uploadFile(MultipartFile file, String directory) throws IOException {
+        log.info("uploadFile 실행, file: {} / directory: {}", file, directory);
         return s3Uploader.upload(file, directory);
     }
 
     public void deleteFile(String fileUrl) throws IOException {
+        log.info("deleteFile 실행, fileUrl: {}", fileUrl);
         s3Uploader.deleteFile(fileUrl);
     }
 }

--- a/src/main/java/com/cine/back/board/post/service/PostService.java
+++ b/src/main/java/com/cine/back/board/post/service/PostService.java
@@ -70,7 +70,9 @@ public class PostService {
     public void deleteBoard(Long postNo) throws IOException {
         try {
             PostEntity postEntity = entityUtil.findPostById(postNo);
-            fileService.deleteFile(postEntity.getImgUrl());
+            if (postEntity.getImgUrl() != null && !postEntity.getImgUrl().isEmpty()) {
+                fileService.deleteFile(postEntity.getImgUrl());
+            }
             postRepository.delete(postEntity);
             log.info("게시글 삭제 완료 / No: {}", postNo);
         } catch (NoSuchElementException e) {

--- a/src/main/java/com/cine/back/board/post/service/PostService.java
+++ b/src/main/java/com/cine/back/board/post/service/PostService.java
@@ -80,16 +80,23 @@ public class PostService {
     }
 
     @Transactional
-    public PostResponseDto modifyBoard(Long postNo, PostRequestDto postDto, MultipartFile imgFile)
+    public PostResponseDto modifyBoard(Long postNo, PostRequestDto postDto, MultipartFile imgFile, boolean deleteImage)
             throws IOException {
         try {
             PostEntity postEntity = entityUtil.findPostById(postNo);
-            String boardImgUrl = null;
-            if (!imgFile.isEmpty()) {
+            if (deleteImage && postEntity.getImgUrl() != null) {
+                log.info("게시글 이미지 삭제 요청");
                 fileService.deleteFile(postEntity.getImgUrl());
-                boardImgUrl = fileService.uploadFile(imgFile, "boardImages");
+                postEntity.setImgUrl(null);
             }
-            PostEntity updatedBoard = postMapper.updatePostEntity(postEntity, postDto, boardImgUrl);
+            if (imgFile != null && !imgFile.isEmpty()) {
+                if (postEntity.getImgUrl() != null) {
+                    log.info("게시글 이미지 교체 요청");
+                    fileService.deleteFile(postEntity.getImgUrl());
+                }
+                postEntity.setImgUrl(fileService.uploadFile(imgFile, "boardImages"));
+            }
+            PostEntity updatedBoard = postMapper.updatePostEntity(postEntity, postDto, postEntity.getImgUrl());
             List<String> tagNames = tagService.updateTags(updatedBoard, postDto.tagNames());
             log.info("게시글 수정 완료 No: {}", updatedBoard.getPostNo());
             PostResponseDto responseDto = postMapper.toResponseDto(updatedBoard, tagNames);

--- a/src/main/java/com/cine/back/board/util/EntityUtil.java
+++ b/src/main/java/com/cine/back/board/util/EntityUtil.java
@@ -11,9 +11,11 @@ import com.cine.back.board.post.repository.PostRepository;
 
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class EntityUtil {
 
     private final PostRepository postRepository;
@@ -21,31 +23,37 @@ public class EntityUtil {
     private final ReplyRepository replyRepository;
 
     public PostEntity findPostById(Long postNo) {
+        log.info("findPostById 실행, 찾는 PostNo: {}", postNo);
         return postRepository.findById(postNo)
                 .orElseThrow(() -> new EntityNotFoundException("게시물을 찾을 수 없습니다."));
     }
 
     public CommentEntity findCommentById(Long commentNo) {
+        log.info("findCommentById 실행, 찾는 commentNo: {}", commentNo);
         return commentRepository.findById(commentNo)
                 .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
     }
 
     public ReplyEntity findReplyById(Long replyNo) {
+        log.info("findReplyById 실행, 찾는 replyNo: {}", replyNo);
         return replyRepository.findById(replyNo)
                 .orElseThrow(() -> new EntityNotFoundException("대댓글을 찾을 수 없습니다."));
     }
 
     public void updateCommentCount(Long postNo) {
+        log.info("updateCommentCount 실행, postNo: {}", postNo);
         PostEntity post = findPostById(postNo);
         post.setCommentCount(post.getCommentCount() + 1);
     }
 
     public void deleteCommentCount(Long postNo) {
+        log.info("deleteCommentCount 실행, postNo: {}", postNo);
         PostEntity post = findPostById(postNo);
         post.setCommentCount(post.getCommentCount() - 1);
     }
 
     public PostEntity updateHitCount(PostEntity post) {
+        log.info("updateHitCount 실행, postNo: {}", post.getPostNo());
         post.setHitCount(post.getHitCount() + 1);
         return post;
     }


### PR DESCRIPTION
1. 게시물 이미지 수정/삭제 로직 변경
-이미지가 있는 상태에서 글을 수정하는 경우(이미지 유지), 이미지가 없는 상태에서 이미지를 추가하는 경우(이미지 추가), 이미지가 있는 상태에서이미지만 삭제하는 경우(기존 이미지 삭제) 등 각 상황에 맞춘 로직 변경

2. 파일전달이 아닌 경우 @RequestBody로 파라미터 변경

3. 유틸 및 서비스에 로깅 추가