### PR TITLE
Fix : 연관검색어 기능 수정

### DIFF
--- a/src/main/java/com/cine/back/movieList/controller/MovieListController.java
+++ b/src/main/java/com/cine/back/movieList/controller/MovieListController.java
@@ -3,12 +3,14 @@ package com.cine.back.movieList.controller;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.cine.back.movieList.dto.Genre;
@@ -41,7 +43,6 @@ public class MovieListController implements MovieListControllerDocs {
     @Override
     @PostMapping("/genresList")
     public ResponseEntity<Optional<List<MovieDetailEntity>>> getMovieGenres(@RequestBody Genre genre) {
-        System.out.println("장르별 조회 컨트롤러------------------" + genre);
         log.info("장르별 조회 컨트롤러");
         Optional<List<MovieDetailEntity>> genresList = movieListService.getMovieGenres(genre);
         return ResponseEntity.ok().body(genresList);
@@ -65,4 +66,39 @@ public class MovieListController implements MovieListControllerDocs {
         return ResponseEntity.ok().body(movieDetail);
     }
 
+    // 영화명, 배우, 장르로 검색
+    @GetMapping("/search/{keyword}")
+    public ResponseEntity<List<MovieDetailEntity>> searchByKeyword(@PathVariable(value = "keyword") String keyword) {
+        log.info("영화 검색 컨트롤러 실행 - 키워드: {}", keyword);
+        try {
+            List<MovieDetailEntity> searchResults = movieListService.searchByKeyword(keyword);
+            if (searchResults.isEmpty()) {
+                log.warn("영화 검색 컨트롤러 - 검색 결과 없음: {}", keyword);
+                return ResponseEntity.noContent().build();
+            }
+            log.info("영화 검색 컨트롤러 - 검색 결과 반환: {}", searchResults);
+            return ResponseEntity.ok(searchResults);
+        } catch (Exception e) {
+            log.error("영화 검색 컨트롤러 - 검색 중 오류 발생: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    // 같은 장르의 영화 추천
+    @GetMapping("/recommend")
+    public ResponseEntity<List<MovieDetailEntity>> recommendSimilarGenreMovies(@RequestParam String genre) {
+        log.info("영화 추천 컨트롤러 컨트롤러 실행 - 장르: {}", genre);
+        try {
+            List<MovieDetailEntity> recommendedMovies = movieListService.recommendSimilarGenre(genre);
+            if (recommendedMovies.isEmpty()) {
+                log.warn("영화 추천 컨트롤러 - 추천할 영화 없음: {}", genre);
+                return ResponseEntity.noContent().build();
+            }
+            log.info("영화 추천 컨트롤러 - 추천 영화 반환: {}", recommendedMovies);
+            return ResponseEntity.ok(recommendedMovies);
+        } catch (Exception e) {
+            log.error("영화 추천 컨트롤러 - 추천 중 오류 발생: ", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }

--- a/src/main/java/com/cine/back/movieList/controller/MovieListControllerDocs.java
+++ b/src/main/java/com/cine/back/movieList/controller/MovieListControllerDocs.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import com.cine.back.movieList.dto.Genre;
 import com.cine.back.movieList.entity.MovieDetailEntity;
@@ -56,4 +57,18 @@ public interface MovieListControllerDocs {
         })
         ResponseEntity<Optional<MovieDetailEntity>> getMovieDetail(
                         @PathVariable(value = "movieId") int movieId);
+
+        // 영화 검색
+        @Operation(summary = "검색한 영화 정보 반환", description = "검색한 영화 정보를 불러옵니다.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "검색한 영화 정보 반환 성공"),
+                        @ApiResponse(responseCode = "400", description = "검색한 영화 정보 반환 실패") })
+        public ResponseEntity<List<MovieDetailEntity>> searchByKeyword(@PathVariable String keyword);
+
+        // 비슷한 장르의 영화 추천
+        @Operation(summary = "영화 추천", description = "검색결과가 없을 시, 같으 장르의 정보를 불러옵니다.")
+        @ApiResponses(value = {
+                        @ApiResponse(responseCode = "200", description = "같은 장르의 영화 정보 반환 성공"),
+                        @ApiResponse(responseCode = "400", description = "같은 장르의 영화 정보 반환 실패") })
+        public ResponseEntity<List<MovieDetailEntity>> recommendSimilarGenreMovies(@RequestParam String genre);
 }

--- a/src/main/java/com/cine/back/movieList/repository/MovieDetailRepository.java
+++ b/src/main/java/com/cine/back/movieList/repository/MovieDetailRepository.java
@@ -7,15 +7,22 @@ import com.cine.back.movieList.entity.MovieDetailEntity;
 import java.util.*;
 
 public interface MovieDetailRepository extends JpaRepository<MovieDetailEntity, Integer> {
-    
+
     Optional<MovieDetailEntity> findByMovieId(int movieId);
-    
+
     Optional<List<MovieDetailEntity>> findAllByOrderByPopularityAsc();
-    
+
     @Query("SELECT md FROM movie_details md JOIN md.genres g WHERE g.name = :genre")
     Optional<List<MovieDetailEntity>> findByGenres(@Param("genre") String genre);
 
     @Query("SELECT md FROM movie_details md JOIN md.credits.cast c WHERE c.name = :actor")
     Optional<List<MovieDetailEntity>> findByActors(@Param("actor") String actor);
-    
+
+    // 영화명, 배우, 장르로 검색
+    List<MovieDetailEntity> findByTitleContainingOrCredits_Cast_NameOrGenres_Name(String title,
+            String castName, String genreName);
+
+    // 비슷한 장르의 영화 추천
+    public List<MovieDetailEntity> findByGenres_NameOrderByReleaseDateDesc(String genre);
+
 }

--- a/src/main/java/com/cine/back/movieList/service/MovieListService.java
+++ b/src/main/java/com/cine/back/movieList/service/MovieListService.java
@@ -65,4 +65,32 @@ public class MovieListService {
         }
     }
 
+    // 영화명, 배우, 장르로 검색
+    public List<MovieDetailEntity> searchByKeyword(String keyword) {
+        log.info("영화 검색 서비스 - 키워드: {}", keyword);
+        try {
+            List<MovieDetailEntity> searchResults = movieDetailRepository
+                    .findByTitleContainingOrCredits_Cast_NameOrGenres_Name(keyword, keyword, keyword);
+            if (searchResults.isEmpty()) {
+                log.warn("검색 결과 없음 - '{}'에 대한 영화를 찾지 못했습니다.", keyword);
+                // 검색 결과가 없을 경우 비슷한 장르의 영화 추천
+                return recommendSimilarGenre(keyword);
+            }
+            return searchResults;
+        } catch (Exception e) {
+            log.error("영화 검색 서비스 - 키워드 검색 실패", e);
+            return List.of();
+        }
+    }
+
+    // 비슷한 장르 영화 추천
+    public List<MovieDetailEntity> recommendSimilarGenre(String genre) {
+        log.info("영화 추천 서비스 - 같은 장르 영화 추천: {}", genre);
+        try {
+            return movieDetailRepository.findByGenres_NameOrderByReleaseDateDesc(genre);
+        } catch (Exception e) {
+            log.error("영화 추천 서비스 - 같은 장르 영화 추천 실패", e);
+            return List.of();
+        }
+    }
 }

--- a/src/main/java/com/cine/back/search/controller/RelatedController.java
+++ b/src/main/java/com/cine/back/search/controller/RelatedController.java
@@ -1,11 +1,9 @@
 package com.cine.back.search.controller;
 
-import com.cine.back.search.entity.SearchEntity;
+import com.cine.back.search.dto.SearchRequest;
 import com.cine.back.search.service.RelatedService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,24 +11,21 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping("/related")
+@RequestMapping("related")
 @RequiredArgsConstructor
 public class RelatedController {
 
     private final RelatedService relatedService;
 
     @PostMapping("/save")
-    public ResponseEntity<String> saveRelatedEntity(@RequestBody SearchEntity searchEntity,
-            @RequestBody String secondaryKeyword) {
+    public void saveRelated(@RequestBody SearchRequest searchRequest) {
+        log.info("연관 검색어 저장 컨트롤러 실행: {}", searchRequest);
         try {
-            relatedService.saveRelatedEntity(searchEntity, secondaryKeyword);
-            log.info("연관 검색어 저장 요청 처리 완료 - Primary 키워드: '{}', Secondary 키워드: '{}'",
-                    searchEntity.getSearchKeyword(), secondaryKeyword);
-            return ResponseEntity.ok("연관 검색어 저장 성공");
+            relatedService.saveRelatedEntity(searchRequest);
+            log.info("연관 검색어 저장 컨트롤러 - 성공. searchListNo: {}",
+                    searchRequest.searchListNo());
         } catch (Exception e) {
-            log.error("연관 검색어 저장 요청 처리 중 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("연관 검색어 저장 실패");
+            log.error("연관 검색어 저장 컨트롤러 - 오류. searchListNo: {}", searchRequest.searchListNo(), e);
         }
     }
-
 }

--- a/src/main/java/com/cine/back/search/controller/RelatedControllerDocs.java
+++ b/src/main/java/com/cine/back/search/controller/RelatedControllerDocs.java
@@ -1,7 +1,8 @@
 package com.cine.back.search.controller;
 
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import com.cine.back.search.dto.SearchRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,6 +16,5 @@ public interface RelatedControllerDocs {
                         @ApiResponse(responseCode = "200", description = "연관검색어 저장 성공"),
                         @ApiResponse(responseCode = "400", description = "연관검색어 저장 실패")
         })
-        public ResponseEntity<String> saveRelatedEntity(@RequestBody String primaryKeyword,
-                        @RequestBody String secondaryKeyword);
+        public void saveRelated(@RequestBody SearchRequest searchRequest);
 }

--- a/src/main/java/com/cine/back/search/controller/SearchController.java
+++ b/src/main/java/com/cine/back/search/controller/SearchController.java
@@ -28,16 +28,13 @@ public class SearchController implements SearchControllerDocs {
     private final SearchService searchService;
 
     @PostMapping("/saveSearchList")
-    public ResponseEntity<Void> saveSearchData(@RequestBody SearchRequest request) {
-        log.info("검색어 저장 컨트롤러 실행");
-        try {
-            searchService.saveSearchList(request);
-            log.info("검색어 저장 컨트롤러 - 성공");
-            return ResponseEntity.status(HttpStatus.CREATED).build();
-        } catch (Exception e) {
-            log.error("검색어 저장 컨트롤러 - 실패", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+    public ResponseEntity<Integer> saveSearchList(@RequestBody SearchRequest request) {
+        log.info("검색어 저장 요청: {}", request);
+        int searchListNo = searchService.saveSearchList(request);
+        if (searchListNo == -1) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(searchListNo);
         }
+        return ResponseEntity.ok().body(searchListNo);
     }
 
     @GetMapping("/user/{userId}")

--- a/src/main/java/com/cine/back/search/controller/SearchControllerDocs.java
+++ b/src/main/java/com/cine/back/search/controller/SearchControllerDocs.java
@@ -21,7 +21,7 @@ public interface SearchControllerDocs {
         @ApiResponses(value = {
                         @ApiResponse(responseCode = "200", description = "사용자의 검색어 저장 성공"),
                         @ApiResponse(responseCode = "400", description = "사용자의 검색어 저장 실패") })
-        public ResponseEntity<Void> saveSearchData(@RequestBody SearchRequest request);
+        public ResponseEntity<Integer> saveSearchList(@RequestBody SearchRequest request);
 
         @Operation(summary = "사용자ID로 검색기록 조회", description = "사용자의 검색기록을 조회합니다.")
         @ApiResponses(value = {

--- a/src/main/java/com/cine/back/search/dto/SearchRequest.java
+++ b/src/main/java/com/cine/back/search/dto/SearchRequest.java
@@ -2,4 +2,5 @@ package com.cine.back.search.dto;
 
 import java.util.List;
 
-public record SearchRequest(String userId, List<String> keywords) {}
+public record SearchRequest(int searchListNo, String userId, List<String> keywords) {
+}

--- a/src/main/java/com/cine/back/search/entity/RelatedEntity.java
+++ b/src/main/java/com/cine/back/search/entity/RelatedEntity.java
@@ -1,5 +1,6 @@
 package com.cine.back.search.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -20,14 +21,10 @@ public class RelatedEntity {
     @Column(name = "search_related_no")
     private int searchRelatedNo; // 연관 검색어 ID
 
-    // referencedColumnName : 실제 매핑될 필드 지정
-    @ManyToOne
-    @JoinColumn(name = "search_list_no")
-    private SearchEntity searchEntity;
+    @Column(name = "search_list_no")
+    private int searchListNo; // SearchEntity의 ID
 
-    @Column(name = "search_related_word", length = 1500)
+    @Column(name = "search_related_word", length = 500)
     private String searchRelatedWord; // 연관 검색어
 
-    @Column(name = "search_related_count")
-    private int searchRelatedCount; // 연관 검색어 빈도수
 }

--- a/src/main/java/com/cine/back/search/entity/SearchEntity.java
+++ b/src/main/java/com/cine/back/search/entity/SearchEntity.java
@@ -26,7 +26,4 @@ public class SearchEntity {
     @Column(name = "search_list_time")
     private LocalDateTime searchListTime = LocalDateTime.now(); // 검색한 시간
 
-    @OneToMany(mappedBy = "searchEntity", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<RelatedEntity> relatedEntities;
-
 }

--- a/src/main/java/com/cine/back/search/repository/RelatedRepository.java
+++ b/src/main/java/com/cine/back/search/repository/RelatedRepository.java
@@ -9,12 +9,6 @@ import com.cine.back.search.entity.RelatedEntity;
 
 @Repository
 public interface RelatedRepository extends JpaRepository<RelatedEntity, Integer> {
-
-    // 주어진 SearchEntity와 연관된 Secondary Keyword로 조회
-    RelatedEntity findBySearchRelatedWordAndSearchEntity_SearchListNo(
-            String searchRelatedWord, int searchListNo);
-
     // 연관검색어 조회
     List<RelatedEntity> findAllBySearchRelatedWord(String secondaryKeyword);
-
 }

--- a/src/main/java/com/cine/back/search/repository/SearchRepository.java
+++ b/src/main/java/com/cine/back/search/repository/SearchRepository.java
@@ -1,6 +1,7 @@
 package com.cine.back.search.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -9,17 +10,21 @@ import com.cine.back.search.entity.SearchEntity;
 
 @Repository
 public interface SearchRepository extends JpaRepository<SearchEntity, Integer> {
-
     // 사용자ID로 검색 (날짜 내림차순)
     List<SearchEntity> findByUserIdOrderBySearchListTimeDesc(String userId);
 
-    // 주어진 검색어로 검색 엔터티를 찾습니다.
-    SearchEntity findBySearchKeyword(String searchKeyword);
+    // 검색어로 조회
+    List<SearchEntity> findBySearchKeyword(String searchKeyword);
+
+    // 검색어번호로 조회
+    SearchEntity findBySearchListNo(int searchListNo);
+
+    // 특정 사용자 ID와 검색어로 검색 기록
+    Optional<SearchEntity> findByUserIdAndSearchKeyword(String userId, String keyword);
 
     // 삭제 - 사용자Id와 검색어번호로 조회
     SearchEntity findByUserIdAndSearchListNo(String userId, int searchListNo);
 
     // 전체삭제
     void deleteByUserId(String userId);
-
 }

--- a/src/main/java/com/cine/back/search/service/RelatedService.java
+++ b/src/main/java/com/cine/back/search/service/RelatedService.java
@@ -1,16 +1,18 @@
 package com.cine.back.search.service;
 
+import com.cine.back.search.dto.SearchRequest;
 import com.cine.back.search.entity.RelatedEntity;
 import com.cine.back.search.entity.SearchEntity;
 import com.cine.back.search.repository.RelatedRepository;
 import com.cine.back.search.repository.SearchRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
 
 @Slf4j
 @Service
@@ -20,52 +22,48 @@ public class RelatedService {
     private final RelatedRepository relatedRepository;
     private final SearchRepository searchRepository;
 
-    // 연관 검색어 저장
-    // primaryKeyword : 기본 검색어
-    // secondaryKeyword : 연관 검색어
     @Transactional
-    public void saveRelatedEntity(SearchEntity searchEntity, String secondaryKeyword) {
+    public void saveRelatedEntity(SearchRequest searchRequest) {
         log.info("연관 검색어 저장 서비스 - 시작");
-
-        // primaryKeyword로 검색어 entity를 조회
-        SearchEntity primarySearchEntity = searchRepository.findBySearchKeyword(searchEntity.getSearchKeyword());
-
-        saveOrUpdateRelatedEntity(primarySearchEntity, secondaryKeyword);
+        int previousSearchListNo = searchRequest.searchListNo();
+        log.info(
+                "연관 검색어 저장 서비스 - previousSearchListNo: {}",
+                previousSearchListNo);
+        List<String> keywords = searchRequest.keywords();
+        for (String keyword : keywords) {
+            processRelatedEntity(previousSearchListNo, keyword);
+        }
         log.info("연관 검색어 저장 서비스 - 완료");
     }
 
-    // 연관 검색어 엔티티를 저장 또는 업데이트
-    // 새로운 연관 검색어 생성 or 기존에 있던 연관 검색어 카운트 업데이트
-    private void saveOrUpdateRelatedEntity(SearchEntity searchEntity, String secondaryKeyword) {
-        List<RelatedEntity> relatedEntities = relatedRepository.findAllBySearchRelatedWord(secondaryKeyword);
-        RelatedEntity relatedEntity = createRelatedEntity(searchEntity,
-                secondaryKeyword, relatedEntities);
-        relatedRepository.save(relatedEntity);
-    }
+    public List<RelatedEntity> processRelatedEntity(int previousSearchListNo, String keyword) {
+        log.info("연관 검색어 저장/업데이트 서비스 - 시작");
 
-    private RelatedEntity createRelatedEntity(SearchEntity searchEntity, String secondaryKeyword,
-            List<RelatedEntity> relatedEntities) {
-        if (relatedEntities.isEmpty()) {
-            return newRelatedEntity(searchEntity, secondaryKeyword);
+        SearchEntity searchEntity = searchRepository.findBySearchListNo(previousSearchListNo);
+        if (searchEntity == null) {
+            log.warn(
+                    "연관 검색어 저장/업데이트 실패 - previousSearchListNo: {}",
+                    previousSearchListNo);
+            return Collections.emptyList();
         }
-        // get(0) : 첫번째 요소를 가져오는 이유?
-        // 이미 존재하는 연관검색어는 하나만 존재함
-        return updateRelatedEntity(relatedEntities.get(0));
+        List<RelatedEntity> relatedEntities = saveRelatedEntity(searchEntity, keyword);
+        log.info("연관 검색어 저장/업데이트 서비스 - 완료");
+        return relatedEntities;
     }
 
-    private RelatedEntity newRelatedEntity(SearchEntity searchEntity, String secondaryKeyword) {
+    private List<RelatedEntity> saveRelatedEntity(SearchEntity searchEntity, String keyword) {
+        RelatedEntity relatedEntity = createRelatedEntity(searchEntity, keyword);
+        relatedRepository.save(relatedEntity);
+        log.info("연관 검색어 저장/업데이트 - 키워드 '{}'", keyword);
+        List<RelatedEntity> resultList = new ArrayList<>();
+        resultList.add(relatedEntity);
+        return resultList;
+    }
+
+    private RelatedEntity createRelatedEntity(SearchEntity searchEntity, String keyword) {
         RelatedEntity relatedEntity = new RelatedEntity();
-        relatedEntity.setSearchEntity(searchEntity);
-        relatedEntity.setSearchRelatedWord(secondaryKeyword);
-        relatedEntity.setSearchRelatedCount(1);
-        log.info("연관 검색어 새로 생성 - 키워드 '{}'", secondaryKeyword);
-        return relatedEntity;
-    }
-
-    private RelatedEntity updateRelatedEntity(RelatedEntity relatedEntity) {
-        relatedEntity.setSearchRelatedCount(relatedEntity.getSearchRelatedCount() +
-                1);
-        log.info("연관 검색어 카운트 증가 - 키워드 '{}'", relatedEntity.getSearchRelatedWord());
+        relatedEntity.setSearchListNo(searchEntity.getSearchListNo());
+        relatedEntity.setSearchRelatedWord(keyword);
         return relatedEntity;
     }
 }


### PR DESCRIPTION
- 왜래키 삭제
1) 검색어 삭제시, 연관검색어 데이터 정보가 남아있어야 연관검색어 기능을 만들 수 있는데, searchListNO - 외래키로 인해 충돌나서 삭제함

- 연관검색어 기능 수정 (DB저장)
1) 첫번째 검색어는 연관검색어 저장 X
2-1) 검색어 저장 로직 : 이미 있는 검색어는 다시 저장 X 
2-2)연관검색어 저장 로직 : 이미 있는 검색어는 기존 searchListNo으로 새로 저장됨